### PR TITLE
Revert "Changed the default address from0x60 to 0x40"

### DIFF
--- a/adafruit_pca9685/motor.py
+++ b/adafruit_pca9685/motor.py
@@ -5,7 +5,7 @@ _DC_MOTORS = ((8, 9, 10), (13, 12, 11), (2, 3, 4), (7, 6, 5))
 
 
 class DCMotors:
-    def __init__(self, i2c, address=0x40, freq=1600):
+    def __init__(self, i2c, address=0x60, freq=1600):
         self.pca9685 = pca9685.PCA9685(i2c, address)
         self.pca9685.freq(freq)
 

--- a/adafruit_pca9685/stepper.py
+++ b/adafruit_pca9685/stepper.py
@@ -161,7 +161,7 @@ class StepperMotor:
 
 
 class Steppers:
-    def __init__(self, i2c, address=0x40, freq=1600):
+    def __init__(self, i2c, address=0x60, freq=1600):
         self.pca9685 = pca9685.PCA9685(i2c, address)
         self.pca9685.freq(freq)
 


### PR DESCRIPTION
Reverts adafruit/Adafruit_CircuitPython_PCA9685#2

Looks like it varies depending on the board. The Learn guides depend on the 0x60 default.