### PR TITLE
removed reference to import ustruct

### DIFF
--- a/adafruit_pca9685/pca9685.py
+++ b/adafruit_pca9685/pca9685.py
@@ -1,4 +1,4 @@
-import ustruct
+
 import time
 
 from adafruit_register import i2c_struct


### PR DESCRIPTION
as a result of [adafruit/circuitpython] Refine `ustruct` into `struct` in shared-bindings and shared-module. (#205).  in this case i removed a import ustruct since the code did not use ustruct methods