### PR TITLE
Fixed issue 31 PCA9685 configured to take i2c commands from all addre…

### DIFF
--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -160,7 +160,8 @@ class PCA9685:
         self.prescale_reg = prescale  # Prescale
         self.mode1_reg = old_mode  # Mode 1
         time.sleep(0.005)
-        self.mode1_reg = old_mode | 0xa0 # Mode 1, autoincrement on, fix to stop pca9685 from accepting commands at all addresses
+        # Mode 1, autoincrement on, fix to stop pca9685 from accepting commands at all addresses
+        self.mode1_reg = old_mode | 0xa0
 
     def __enter__(self):
         return self

--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -160,7 +160,7 @@ class PCA9685:
         self.prescale_reg = prescale  # Prescale
         self.mode1_reg = old_mode  # Mode 1
         time.sleep(0.005)
-        self.mode1_reg = old_mode | 0xA1  # Mode 1, autoincrement on
+        self.mode1_reg = old_mode | 0xa0 # Mode 1, autoincrement on, fix to stop pca9685 from accepting commands at all addresses
 
     def __enter__(self):
         return self

--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -161,7 +161,7 @@ class PCA9685:
         self.mode1_reg = old_mode  # Mode 1
         time.sleep(0.005)
         # Mode 1, autoincrement on, fix to stop pca9685 from accepting commands at all addresses
-        self.mode1_reg = old_mode | 0xa0
+        self.mode1_reg = old_mode | 0xA0
 
     def __enter__(self):
         return self

--- a/examples/pca9685_servo.py
+++ b/examples/pca9685_servo.py
@@ -3,12 +3,12 @@
 from board import SCL, SDA
 import busio
 
-# Import the PCA9685 module.
-from adafruit_pca9685 import PCA9685
-
 # This example also relies on the Adafruit motor library available here:
 # https://github.com/adafruit/Adafruit_CircuitPython_Motor
 from adafruit_motor import servo
+
+# Import the PCA9685 module.
+from adafruit_pca9685 import PCA9685
 
 i2c = busio.I2C(SCL, SDA)
 


### PR DESCRIPTION
…sses

Issue description:
I'm combining my PCA9685 with HT16K33 8x8 matrix.
As soon as I send a command to the HT1633 the PCA stops responding and all my connected servos go limp.

The solution for this issue was identified here: rwaldron/johnny-five#1591 (comment)

It appears the issue was fixed in the arduino library but not corrected in circuit python (see adafruit/Adafruit-PWM-Servo-Driver-Library@9f8e1dd#diff-5d1e3a5213c0ef6dedb2baf5cc323727L106-R110)

I confirmed the fix below works for me:
Change line 163 of adafruit_pca9685 in frequency(self, freq) from
self.mode1_reg = old_mode | 0xa1 # Mode 1, autoincrement on
to
self.mode1_reg = old_mode | 0xa0 # Mode 1, autoincrement on, fix to stop pca9685 from accepting commands at all addresses

I will submit a pull request with this change.