### PR TITLE
fixed pca9685_servo.py example

### DIFF
--- a/examples/pca9685_servo.py
+++ b/examples/pca9685_servo.py
@@ -8,8 +8,8 @@ import busio
 
 # Import the PCA9685 module. Available in the bundle and here:
 #   https://github.com/adafruit/Adafruit_CircuitPython_PCA9685
-from adafruit_pca9685 import PCA9685
 from adafruit_motor import servo
+from adafruit_pca9685 import PCA9685
 
 i2c = busio.I2C(SCL, SDA)
 

--- a/examples/pca9685_servo.py
+++ b/examples/pca9685_servo.py
@@ -1,42 +1,59 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-# This example moves a servo its full range (180 degrees by default) and then back.
+import time
 
 from board import SCL, SDA
 import busio
 
-# This example also relies on the Adafruit motor library available here:
-# https://github.com/adafruit/Adafruit_CircuitPython_Motor
-from adafruit_motor import servo
-
-# Import the PCA9685 module.
+# Import the PCA9685 module. Available in the bundle and here:
+#   https://github.com/adafruit/Adafruit_CircuitPython_PCA9685
 from adafruit_pca9685 import PCA9685
+from adafruit_motor import servo
 
 i2c = busio.I2C(SCL, SDA)
 
 # Create a simple PCA9685 class instance.
 pca = PCA9685(i2c)
+# You can optionally provide a finer tuned reference clock speed to improve the accuracy of the
+# timing pulses. This calibration will be specific to each board and its environment. See the
+# calibration.py example in the PCA9685 driver.
+# pca = PCA9685(i2c, reference_clock_speed=25630710)
 pca.frequency = 50
 
 # To get the full range of the servo you will likely need to adjust the min_pulse and max_pulse to
 # match the stall points of the servo.
 # This is an example for the Sub-micro servo: https://www.adafruit.com/product/2201
-# servo7 = servo.Servo(pca.channels[7], min_pulse=580, max_pulse=2480)
+# servo7 = servo.Servo(pca.channels[7], min_pulse=580, max_pulse=2350)
 # This is an example for the Micro Servo - High Powered, High Torque Metal Gear:
 #   https://www.adafruit.com/product/2307
-# servo7 = servo.Servo(pca.channels[7], min_pulse=600, max_pulse=2400)
+# servo7 = servo.Servo(pca.channels[7], min_pulse=500, max_pulse=2600)
 # This is an example for the Standard servo - TowerPro SG-5010 - 5010:
 #   https://www.adafruit.com/product/155
-# servo7 = servo.Servo(pca.channels[7], min_pulse=600, max_pulse=2500)
+# servo7 = servo.Servo(pca.channels[7], min_pulse=400, max_pulse=2400)
 # This is an example for the Analog Feedback Servo: https://www.adafruit.com/product/1404
-# servo7 = servo.Servo(pca.channels[7], min_pulse=600, max_pulse=2600)
+# servo7 = servo.Servo(pca.channels[7], min_pulse=600, max_pulse=2500)
+# This is an example for the Micro servo - TowerPro SG-92R: https://www.adafruit.com/product/169
+# servo7 = servo.Servo(pca.channels[7], min_pulse=500, max_pulse=2400)
 
-# The pulse range is 1000 - 2000 by default.
+# The pulse range is 750 - 2250 by default. This range typically gives 135 degrees of
+# range, but the default is to use 180 degrees. You can specify the expected range if you wish:
+# servo7 = servo.Servo(pca.channels[7], actuation_range=135)
 servo7 = servo.Servo(pca.channels[7])
 
+# We sleep in the loops to give the servo time to move into position.
 for i in range(180):
     servo7.angle = i
+    time.sleep(0.03)
 for i in range(180):
     servo7.angle = 180 - i
+    time.sleep(0.03)
+
+# You can also specify the movement fractionally.
+fraction = 0.0
+while fraction < 1.0:
+    servo7.fraction = fraction
+    fraction += 0.01
+    time.sleep(0.03)
+
 pca.deinit()


### PR DESCRIPTION
I copied the servo sweep example from CircuitPython-Motor as it's the same example but that one has the delays in place.

The code was tested in a raspberry pi.
