### PR TITLE
update comment to refer to pwmio.PWMOut instead of pulseio

### DIFF
--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -42,7 +42,7 @@ from adafruit_bus_device import i2c_device
 
 
 class PWMChannel:
-    """A single PCA9685 channel that matches the :py:class:`~pulseio.PWMOut` API."""
+    """A single PCA9685 channel that matches the :py:class:`~pwmio.PWMOut` API."""
 
     def __init__(self, pca, index):
         self._pca = pca


### PR DESCRIPTION
This updates a reference to `pulseio.PWMOut` in a comment to be `pwmio.PWMOut` which is the sole place that PWMOut is located starting with CP7.