### PR TITLE
Add access to MODE2 register

### DIFF
--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -113,6 +113,7 @@ class PCA9685:
 
     # Registers:
     mode1_reg = UnaryStruct(0x00, "<B")
+    mode2_reg = UnaryStruct(0x01, "<B")
     prescale_reg = UnaryStruct(0xFE, "<B")
     pwm_regs = StructArray(0x06, "<HH", 16)
 


### PR DESCRIPTION
Solves the issue from Issue #38.  Gives access to the register so it can be manipulated manually but the class doesn't do so itself currently.