### PR TITLE
Suggesting an error message solution

### DIFF
--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -152,11 +152,12 @@ class PCA9685:
     @property
     def frequency(self) -> float:
         """The overall PWM frequency in Hertz."""
-        if self.prescale_reg < 3:
+        prescale_result = self.prescale_reg
+        if prescale_result < 3:
             raise ValueError(
                 "The device pre_scale register (0xFE) was not read or returned a value < 3"
             )
-        return self.reference_clock_speed / 4096 / self.prescale_reg
+        return self.reference_clock_speed / 4096 / prescale_result
 
     @frequency.setter
     def frequency(self, freq: float) -> None:

--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -82,7 +82,7 @@ class PWMChannel:
     @duty_cycle.setter
     def duty_cycle(self, value: int) -> None:
         if not 0 <= value <= 0xFFFF:
-            raise ValueError(f"Out of range: value {value} not 0 <= value <= 0xFFFF")
+            raise ValueError(f"Out of range: value {value} not 0 <= value <= 65,535")
 
         if value == 0xFFFF:
             self._pca.pwm_regs[self._index] = (0x1000, 0)

--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -82,7 +82,7 @@ class PWMChannel:
     @duty_cycle.setter
     def duty_cycle(self, value: int) -> None:
         if not 0 <= value <= 0xFFFF:
-            raise ValueError("Out of range")
+            raise ValueError(f"Out of range: value {value} not 0 <= value <= 0xFFFF")
 
         if value == 0xFFFF:
             self._pca.pwm_regs[self._index] = (0x1000, 0)
@@ -136,7 +136,7 @@ class PCA9685:
         i2c_bus: I2C,
         *,
         address: int = 0x40,
-        reference_clock_speed: int = 25000000
+        reference_clock_speed: int = 25000000,
     ) -> None:
         self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
         self.channels = PCAChannels(self)
@@ -152,6 +152,10 @@ class PCA9685:
     @property
     def frequency(self) -> float:
         """The overall PWM frequency in Hertz."""
+        if self.prescale_reg < 3:
+            raise ValueError(
+                "The device pre_scale register (0xFE) was not read or returned a value < 3"
+            )
         return self.reference_clock_speed / 4096 / self.prescale_reg
 
     @frequency.setter


### PR DESCRIPTION
resolves #29 
submitted for review / comment.

My 2 cents.  it appears the only way the prescale_reg value can go south (it's read when invoked, I think) would be for I2C to fail.  According the the specsheet for PCA9685 chip, the register should be in the range of  0x03 <= value <= 0xFF.  I've only suggested for the low end, but to be airtight do we want to go the full way?   (spec sheet p 25 of 52)