### PR TITLE
Make duty_cycle return the same value it was set to...

### DIFF
--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -77,7 +77,7 @@ class PWMChannel:
         pwm = self._pca.pwm_regs[self._index]
         if pwm[0] == 0x1000:
             return 0xFFFF
-        elif pwm[1] == 0x1000:
+        if pwm[1] == 0x1000:
             return 0x0000
         return pwm[1] << 4
 

--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -77,6 +77,8 @@ class PWMChannel:
         pwm = self._pca.pwm_regs[self._index]
         if pwm[0] == 0x1000:
             return 0xFFFF
+        elif pwm[1] == 0x1000:
+            return 0x0000
         return pwm[1] << 4
 
     @duty_cycle.setter
@@ -85,10 +87,16 @@ class PWMChannel:
             raise ValueError(f"Out of range: value {value} not 0 <= value <= 65,535")
 
         if value == 0xFFFF:
+            # Special case for "fully on":
             self._pca.pwm_regs[self._index] = (0x1000, 0)
+        elif value < 0x0010:
+            # Special case for "fully off":
+            self._pca.pwm_regs[self._index] = (0, 0x1000)
         else:
             # Shift our value by four because the PCA9685 is only 12 bits but our value is 16
-            value = (value + 1) >> 4
+            value = value >> 4
+            # value should never be zero here because of the test for the "fully off" case
+            # (the LEDn_ON and LEDn_OFF registers should never be set with the same values)
             self._pca.pwm_regs[self._index] = (0, value)
 
 


### PR DESCRIPTION
...albeit with the least significant four bits set to zero (the device only uses the most significant twelve bits and doesn't store the remaining four, so these will be lost).

Also set the special bit for "fully off" instead of setting the LEDn_ON and LEDn_OFF registers to the same value, as instructed in the datasheet.