### PR TITLE
Correct PWM frequency prescale computation

### DIFF
--- a/adafruit_pca9685.py
+++ b/adafruit_pca9685.py
@@ -166,11 +166,11 @@ class PCA9685:
             raise ValueError(
                 "The device pre_scale register (0xFE) was not read or returned a value < 3"
             )
-        return self.reference_clock_speed / 4096 / prescale_result
+        return self.reference_clock_speed / 4096 / (prescale_result + 1)
 
     @frequency.setter
     def frequency(self, freq: float) -> None:
-        prescale = int(self.reference_clock_speed / 4096.0 / freq + 0.5)
+        prescale = int(self.reference_clock_speed / 4096.0 / freq + 0.5) - 1
         if prescale < 3:
             raise ValueError("PCA9685 cannot output at the given frequency")
         old_mode = self.mode1_reg  # Mode 1


### PR DESCRIPTION
Assuming this datasheet https://www.digikey.be/htmldatasheets/production/1640697/0/0/1/pca9685-datasheet.html#pf19 is correct, the prescale value computation is off by one. This results in the incorrect PWM frequency being selected, and the incorrect frequency being reported on reading back the frequency field. For example

- requesting a PWM frequency of the maximum value supported by the chip of 1.5 kHz results in an actual PWM frequency of 1.2 kHz (per the forumula in the datasheet, and verified by oscilloscope), and the value reported by reading the frequency field is also the incorrect value of 1.5 kHz. 
- requesting a PWM frequency of 2 kHz, outside the allowed range, results in an actual PWM frequency of the maximum 1.5 kHz, but 2 kHz is incorrectly reported when the frequency is read back.